### PR TITLE
Update cucumber to 6.9.1, explicit use utf-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
   <build>
@@ -32,13 +34,13 @@
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-java</artifactId>
-      <version>5.7.0</version>
+      <version>6.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit</artifactId>
-      <version>5.7.0</version>
+      <version>6.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
PR suggests
1. update cucumber to 6.9.1
2. make explicit use of UTF-8 to make build platform independent (currently there is maven warning `[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!`)